### PR TITLE
fix(ui): position modal close button relative to image

### DIFF
--- a/src/zimage/static/css/app.css
+++ b/src/zimage/static/css/app.css
@@ -44,6 +44,10 @@ body { background-color: #f8f9fa; }
             position: relative;
             text-align: center;
         }
+        .modal-image-wrapper {
+            position: relative;
+            display: inline-block;
+        }
         .modal-image-full {
             max-height: 90vh;
             max-width: 100%;

--- a/src/zimage/static/index.html
+++ b/src/zimage/static/index.html
@@ -269,10 +269,12 @@
         <div class="modal-dialog modal-dialog-custom modal-dialog-centered">
             <div class="modal-content modal-content-custom">
                 <div class="modal-body modal-body-custom">
-                    <button type="button" class="close-btn-custom" data-bs-dismiss="modal" aria-label="Close">
-                        <i class="bi bi-x-lg"></i>
-                    </button>
-                    <img id="modalImage" src="" alt="Generated Image Preview" class="modal-image-full">
+                    <div class="modal-image-wrapper">
+                        <button type="button" class="close-btn-custom" data-bs-dismiss="modal" aria-label="Close">
+                            <i class="bi bi-x-lg"></i>
+                        </button>
+                        <img id="modalImage" src="" alt="Generated Image Preview" class="modal-image-full">
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes the issue where the close button on the image modal was positioned far away from the image when the image was smaller than the screen.

The close button is now positioned relative to the image itself, ensuring it is always at the top-right corner of the image.

**Changes:**
- Wrapped the modal image and close button in a `.modal-image-wrapper` div.
- Added CSS for `.modal-image-wrapper` to use `display: inline-block` and `position: relative`.