### PR TITLE
feat(webui): improve image download reliability for mobile devices

### DIFF
--- a/src/zimage/server.py
+++ b/src/zimage/server.py
@@ -378,6 +378,24 @@ async def delete_history_item(item_id: int):
     
     return {"message": "History item and associated file deleted successfully"}
 
+@app.get("/download/{filename}")
+async def download_image(filename: str):
+    """Serve the image file as an attachment to force download."""
+    # Basic path traversal protection: ensure filename is just a name
+    if "/" in filename or "\\" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    file_path = OUTPUTS_DIR / filename
+    if not file_path.exists() or not file_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    
+    return FileResponse(
+        file_path, 
+        media_type="image/png", 
+        filename=filename,
+        content_disposition_type="attachment"
+    )
+
 # Serve generated images
 app.mount("/outputs", StaticFiles(directory=OUTPUTS_DIR), name="outputs")
 

--- a/src/zimage/static/js/main.js
+++ b/src/zimage/static/js/main.js
@@ -852,7 +852,7 @@
                 };
                 previewContainer.appendChild(img);
             }
-            if (downloadBtn) downloadBtn.href = imageUrl;
+            if (downloadBtn) downloadBtn.href = `/download/${encodeURIComponent(item.filename)}`;
             
             // Meta
             const t = translations[currentLanguage] || translations.en || {};
@@ -980,7 +980,10 @@
                             };
                             previewContainer.appendChild(img);
                         }
-                        if (downloadBtn) downloadBtn.href = data.image_url;
+                        if (downloadBtn) {
+                            const filename = data.image_url.split('/').pop();
+                            downloadBtn.href = `/download/${encodeURIComponent(filename)}`;
+                        }
                         
                         const tMeta = translations[currentLanguage] || translations.en || {};
                         const stepsLabelMeta = tMeta.steps_label || 'steps';


### PR DESCRIPTION
This PR implements a more reliable download mechanism for generated images, specifically targeting improvements for mobile browsers (iOS Safari, Android Chrome).

**Changes:**
- **Server:** Added a new `/download/{filename}` endpoint that serves images with `Content-Disposition: attachment`. This forces the browser to treat the navigation as a download, avoiding issues with opening images in the tab or blob URL limitations on mobile.
- **Frontend:** Updated the "Download" button logic to link directly to this new endpoint (e.g., `/download/my-image.png`) instead of the static file path.
- **Security:** Hardened the download endpoint to ensure it only serves files (not directories) and prevents path traversal.
- **Reliability:** Properly encoded filenames in the URL to handle special characters.

**Note:** This approach replaces the previous client-side Blob fetching method, offering a native and more robust solution without triggering unnecessary confirmation dialogs.