### PR TITLE
feat(webui): add share and copy buttons for the images

### DIFF
--- a/src/zimage/static/css/app.css
+++ b/src/zimage/static/css/app.css
@@ -155,6 +155,68 @@ body { background-color: #f8f9fa; }
             min-width: max-content; /* Adjust width to fit content */
         }
 
+        /* Button styling for icon-only and responsive layout */
+        .btn i.bi {
+            font-size: 1rem;
+            line-height: 1;
+        }
+        /* Ensure buttons have consistent height */
+        .btn {
+            min-height: 2.25rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.375rem 0.75rem;
+        }
+        /* Icon + text buttons (desktop) */
+        .btn span.ms-1 {
+            margin-left: 0.25rem !important;
+            font-size: 0.875rem;
+        }
+        /* Desktop button container alignment */
+        #resultInfo .d-flex.gap-2.d-none.d-md-flex {
+            align-items: center;
+        }
+        /* PC Layout: Right-aligned buttons with reasonable sizing */
+        #resultInfo .d-flex.gap-2:not(.d-md-none) {
+            justify-content: flex-end;
+            flex-wrap: nowrap;
+        }
+        #resultInfo .d-flex.gap-2:not(.d-md-none) .btn {
+            min-width: 100px;
+            max-width: 130px;
+        }
+        /* Mobile button styling - full width with text */
+        @media (max-width: 767.98px) {
+            #resultInfo .d-md-none .btn {
+                flex: 1 1 auto;
+                min-width: 100px;
+            }
+            #resultInfo .d-md-none {
+                margin-top: 1rem;
+                padding-top: 1rem;
+                border-top: 1px solid #dee2e6;
+            }
+        }
+        /* Dark mode button adjustments */
+        [data-bs-theme="dark"] #resultInfo .d-md-none {
+            border-top-color: #495057;
+        }
+        /* Mobile portrait: Icon-only buttons to stay in single row */
+        @media (max-width: 575.98px) and (orientation: portrait) {
+            #resultInfo .d-flex.gap-2 .btn span.ms-1 {
+                display: none !important; /* Hide text in portrait */
+            }
+            #resultInfo .d-flex.gap-2 .btn {
+                min-width: 48px!important; /* Smaller for icon-only */
+                padding: 0.25rem 0.5rem;
+                flex: 0 0 auto; /* Prevent flex growth */
+            }
+            #resultInfo .d-flex.gap-2 {
+                justify-content: space-between; /* Even spacing */
+            }
+        }
+        
         /* Dark Mode Overrides */
         [data-bs-theme="dark"] body {
             background-color: #212529;

--- a/src/zimage/static/i18n/en.json
+++ b/src/zimage/static/i18n/en.json
@@ -43,5 +43,18 @@
   "model_desc_full_mps": "Best quality (High VRAM) (full)",
   "model_desc_q8_mps": "Balanced (Low VRAM) (q8)",
   "model_desc_q4_mps": "Low Memory (Lowest VRAM) (q4)",
-  "model_recommended_suffix": " (Recommended)"
+  "model_recommended_suffix": " (Recommended)",
+  "share_btn": "Share",
+  "share_success": "Image shared successfully!",
+  "share_error": "Failed to share image",
+  "share_not_supported": "Sharing not supported in this browser",
+  "copy_btn": "Copy",
+  "copy_success": "Image copied to clipboard!",
+  "copy_error": "Failed to copy image to clipboard",
+  "copy_not_supported": "Clipboard access not supported",
+  "share_unsupported_browser": "Your browser doesn't support direct sharing. Try downloading instead.",
+  "share_requires_https": "Sharing requires a secure connection (HTTPS or localhost)",
+  "app_name": "Z-Image Studio",
+  "no_image_to_share": "No image available to share",
+  "no_image_to_copy": "No image available to copy"
 }

--- a/src/zimage/static/i18n/ja.json
+++ b/src/zimage/static/i18n/ja.json
@@ -43,5 +43,18 @@
   "model_desc_full_mps": "最高画質 (高VRAM) (full)",
   "model_desc_q8_mps": "バランス (低VRAM) (q8)",
   "model_desc_q4_mps": "低メモリ (最低VRAM) (q4)",
-  "model_recommended_suffix": " (推奨)"
+  "model_recommended_suffix": " (推奨)",
+  "share_btn": "共有",
+  "share_success": "画像が共有されました！",
+  "share_error": "画像の共有に失敗しました",
+  "share_not_supported": "このブラウザでは共有がサポートされていません",
+  "copy_btn": "コピー",
+  "copy_success": "画像がクリップボードにコピーされました！",
+  "copy_error": "画像をクリップボードにコピーできませんでした",
+  "copy_not_supported": "クリップボードアクセスがサポートされていません",
+  "share_unsupported_browser": "お使いのブラウザでは直接共有がサポートされていません。ダウンロードをお試しください。",
+  "share_requires_https": "共有には安全な接続（HTTPS または localhost）が必要です",
+  "app_name": "Z-Image Studio",
+  "no_image_to_share": "共有できる画像がありません",
+  "no_image_to_copy": "コピーできる画像がありません"
 }

--- a/src/zimage/static/i18n/zh-CN.json
+++ b/src/zimage/static/i18n/zh-CN.json
@@ -43,5 +43,18 @@
   "model_desc_full_mps": "最佳画质 (高内存) (full)",
   "model_desc_q8_mps": "平衡模式 (中等内存) (q8)",
   "model_desc_q4_mps": "低内存模式 (低内存) (q4)",
-  "model_recommended_suffix": " (推荐)"
+  "model_recommended_suffix": " (推荐)",
+  "share_btn": "分享",
+  "share_success": "图片分享成功！",
+  "share_error": "图片分享失败",
+  "share_not_supported": "此浏览器不支持分享功能",
+  "copy_btn": "复制",
+  "copy_success": "图片已复制到剪贴板！",
+  "copy_error": "无法复制图片到剪贴板",
+  "copy_not_supported": "不支持剪贴板访问",
+  "share_unsupported_browser": "您的浏览器不支持直接分享。请尝试下载。",
+  "share_requires_https": "分享需要安全连接（HTTPS 或 localhost）",
+  "app_name": "Z-Image Studio",
+  "no_image_to_share": "没有可分享的图片",
+  "no_image_to_copy": "没有可复制的图片"
 }

--- a/src/zimage/static/i18n/zh-TW.json
+++ b/src/zimage/static/i18n/zh-TW.json
@@ -43,5 +43,18 @@
   "model_desc_full_mps": "最佳畫質 (高記憶體) (full)",
   "model_desc_q8_mps": "平衡模式 (中等記憶體) (q8)",
   "model_desc_q4_mps": "低記憶體模式 (低記憶體) (q4)",
-  "model_recommended_suffix": " (推薦)"
+  "model_recommended_suffix": " (推薦)",
+  "share_btn": "分享",
+  "share_success": "圖片分享成功！",
+  "share_error": "圖片分享失敗",
+  "share_not_supported": "此瀏覽器不支援分享功能",
+  "copy_btn": "複製",
+  "copy_success": "圖片已複製到剪貼簿！",
+  "copy_error": "無法複製圖片到剪貼簿",
+  "copy_not_supported": "不支援剪貼簿存取",
+  "share_unsupported_browser": "您的瀏覽器不支援直接分享。請嘗試下載。",
+  "share_requires_https": "分享需要安全連線（HTTPS 或 localhost）",
+  "app_name": "Z-Image Studio",
+  "no_image_to_share": "沒有可分享的圖片",
+  "no_image_to_copy": "沒有可複製的圖片"
 }

--- a/src/zimage/static/index.html
+++ b/src/zimage/static/index.html
@@ -223,7 +223,8 @@
                         </div>
                         
                         <div id="resultInfo" class="d-none border-top pt-3">
-                            <div class="d-flex justify-content-between align-items-center">
+                            <!-- Metadata Row (full width) -->
+                            <div class="mb-3">
                                 <div class="text-muted small">
                                     <span id="timeTaken"></span>
                                     <span class="mx-2">|</span>
@@ -239,7 +240,21 @@
                                     <span class="mx-2">|</span>
                                     <span id="metaLoras"></span>
                                 </div>
-                                <a href="#" id="downloadBtn" class="btn btn-success" download data-i18n="download_btn">Download</a>
+                            </div>
+                            <!-- Buttons Row (full width, horizontal) -->
+                            <div class="d-flex gap-2 flex-wrap">
+                                <button id="shareBtn" class="btn btn-primary flex-fill" title="Share" data-i18n-title="share_btn" data-bs-toggle="tooltip" data-bs-placement="top">
+                                    <i class="bi bi-share-fill"></i>
+                                    <span class="ms-1 d-none d-sm-inline" data-i18n="share_btn">Share</span>
+                                </button>
+                                <button id="copyBtn" class="btn btn-outline-primary flex-fill" title="Copy" data-i18n-title="copy_btn" data-bs-toggle="tooltip" data-bs-placement="top">
+                                    <i class="bi bi-clipboard"></i>
+                                    <span class="ms-1 d-none d-sm-inline" data-i18n="copy_btn">Copy</span>
+                                </button>
+                                <a href="#" id="downloadBtn" class="btn btn-success flex-fill" download title="Download" data-i18n-title="download_btn" data-bs-toggle="tooltip" data-bs-placement="top">
+                                    <i class="bi bi-download"></i>
+                                    <span class="ms-1 d-none d-sm-inline" data-i18n="download_btn">Download</span>
+                                </a>
                             </div>
                         </div>
                     </div>
@@ -301,6 +316,17 @@
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <!-- Toast Container for notifications -->
+    <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
+        <div id="shareToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+                <strong class="me-auto" data-i18n="app_name">Z-Image Studio</strong>
+                <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+            <div class="toast-body" id="toastMessage"></div>
         </div>
     </div>
 

--- a/tests/manual_test_share_copy_buttons.md
+++ b/tests/manual_test_share_copy_buttons.md
@@ -1,0 +1,46 @@
+# Manual Test: Share and Copy Buttons Functionality
+
+## Issue Description
+The share and copy buttons on the web UI only work when an image has just been generated. They should also work when loading a history image.
+
+## Test Steps
+
+### Prerequisite
+1. Start the Z-Image Studio server
+2. Generate at least one image to have history
+
+### Test Case 1: Share and Copy Buttons After New Generation
+1. Fill in the prompt and generate a new image
+2. Verify that the share and copy buttons are enabled (not disabled)
+3. Click the share button - it should work (show share dialog or appropriate message)
+4. Click the copy button - it should work (copy image to clipboard or show appropriate message)
+
+### Test Case 2: Share and Copy Buttons After Loading History Image (Main Fix)
+1. Click on the "History" button to open the history drawer
+2. Click on any previously generated image from the history list
+3. Verify that the image loads in the preview area
+4. **CRITICAL TEST**: Verify that the share and copy buttons are now enabled (not disabled)
+5. Click the share button - it should work with the loaded history image
+6. Click the copy button - it should work with the loaded history image
+
+### Test Case 3: Share and Copy Buttons Without Image
+1. Clear the preview by refreshing the page or starting fresh
+2. Verify that the share and copy buttons are disabled
+3. Verify that clicking them shows appropriate error messages
+
+## Expected Results
+- After loading a history image, the share and copy buttons should be enabled
+- The buttons should work with the loaded history image (same functionality as with newly generated images)
+- Without an image, the buttons should be disabled
+
+## Technical Details
+The fix adds a call to `updateShareButtonState()` at the end of the `loadFromHistory()` function in `src/zimage/static/js/main.js`. This ensures that the share and copy buttons are properly enabled/disabled based on the availability of the loaded history image.
+
+## Code Changes
+```javascript
+// In loadFromHistory() function, added at the end:
+// Update share button state after loading history image
+updateShareButtonState();
+```
+
+This ensures the button state is updated whenever a history image is loaded, making the share and copy functionality available for history images just like it is for newly generated images.


### PR DESCRIPTION
The share and copy buttons were added, they will be enabled after generating a new image,  also work when loading images from history.
