### PR TITLE
fix: guard seed parameter to avoid null in history

### DIFF
--- a/src/zimage/mcp_server.py
+++ b/src/zimage/mcp_server.py
@@ -7,6 +7,7 @@ import time
 import os
 import json
 import base64
+import random
 
 try:
     from .hardware import get_available_models, normalize_precision, MODEL_ID_MAP
@@ -80,6 +81,11 @@ async def generate(
     height = height if height % 16 == 0 else (height // 16) * 16
     width = max(16, width)
     height = max(16, height)
+
+    # Generate a random seed if none provided (for reproducibility tracking)
+    if seed is None:
+        seed = random.randint(0, 2**31 - 1)
+        logger.info(f"Generated random seed: {seed}")
 
     start_time = time.time()
 

--- a/tests/test_seed_generation_integration.py
+++ b/tests/test_seed_generation_integration.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for seed generation logic.
+These tests verify the core seed generation algorithm without testing real endpoints.
+Real endpoint testing will be added in future work.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+from pathlib import Path
+import random
+
+
+class TestSeedGenerationLogic(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = Path(__file__).resolve().parent.parent
+        sys.path.insert(0, str(self.repo_root / "src"))
+
+    def test_mcp_server_seed_logic(self):
+        """Test MCP server seed generation logic in isolation."""
+        # Test the seed generation logic that would be used in mcp_server.py
+        
+        # Test case 1: seed=None should generate a random seed
+        seed_input = None
+        if seed_input is None:
+            seed = random.randint(0, 2**31 - 1)
+        else:
+            seed = seed_input
+        
+        self.assertIsNotNone(seed, "Generated seed should not be None")
+        self.assertIsInstance(seed, int, "Generated seed should be an integer")
+        self.assertGreaterEqual(seed, 0, "Generated seed should be non-negative")
+        self.assertLessEqual(seed, 2**31 - 1, "Generated seed should be within valid range")
+        
+        # Test case 2: provided seed should be preserved
+        provided_seed = 12345
+        if provided_seed is None:
+            seed = random.randint(0, 2**31 - 1)
+        else:
+            seed = provided_seed
+        
+        self.assertEqual(seed, provided_seed, "Should preserve provided seed")
+
+    def test_web_server_seed_logic(self):
+        """Test web server seed generation logic in isolation."""
+        # Test the seed generation logic that would be used in server.py
+        
+        # Test case 1: req.seed=None should generate a random seed
+        req_seed = None
+        if req_seed is None:
+            req_seed = random.randint(0, 2**31 - 1)
+        
+        self.assertIsNotNone(req_seed, "Generated seed should not be None")
+        self.assertIsInstance(req_seed, int, "Generated seed should be an integer")
+        self.assertGreaterEqual(req_seed, 0, "Generated seed should be non-negative")
+        self.assertLessEqual(req_seed, 2**31 - 1, "Generated seed should be within valid range")
+        
+        # Test case 2: provided seed should be preserved
+        provided_seed = 12345
+        req_seed = provided_seed
+        if req_seed is None:
+            req_seed = random.randint(0, 2**31 - 1)
+        
+        self.assertEqual(req_seed, provided_seed, "Should preserve provided seed")
+
+    def test_seed_generation_consistency(self):
+        """Test that both server logics generate seeds consistently."""
+        
+        # MCP server logic
+        def mcp_logic(seed_input):
+            if seed_input is None:
+                return random.randint(0, 2**31 - 1)
+            else:
+                return seed_input
+        
+        # Web server logic
+        def web_logic(seed_input):
+            if seed_input is None:
+                return random.randint(0, 2**31 - 1)
+            else:
+                return seed_input
+        
+        # Test with None - both should generate seeds
+        mcp_seed = mcp_logic(None)
+        web_seed = web_logic(None)
+        
+        self.assertIsNotNone(mcp_seed, "MCP logic should generate seed")
+        self.assertIsNotNone(web_seed, "Web logic should generate seed")
+        self.assertIsInstance(mcp_seed, int, "MCP seed should be integer")
+        self.assertIsInstance(web_seed, int, "Web seed should be integer")
+        
+        # Test with provided seed - both should preserve it
+        test_seed = 42
+        mcp_seed = mcp_logic(test_seed)
+        web_seed = web_logic(test_seed)
+        
+        self.assertEqual(mcp_seed, test_seed, "MCP logic should preserve seed")
+        self.assertEqual(web_seed, test_seed, "Web logic should preserve seed")
+
+    def test_seed_range_validation(self):
+        """Test that generated seeds are within valid ranges."""
+        
+        # Generate multiple seeds and verify they're all in range
+        for i in range(10):
+            seed = random.randint(0, 2**31 - 1)
+            
+            # PyTorch compatibility
+            self.assertGreaterEqual(seed, 0, f"Seed {seed} should be >= 0")
+            self.assertLessEqual(seed, 2**31 - 1, f"Seed {seed} should be <= 2^31-1")
+            
+            # SQLite compatibility
+            self.assertGreaterEqual(seed, -2**63, f"Seed {seed} should be >= -2^63")
+            self.assertLessEqual(seed, 2**63 - 1, f"Seed {seed} should be <= 2^63-1")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_web_server_seed.py
+++ b/tests/test_web_server_seed.py
@@ -1,0 +1,160 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+from pathlib import Path
+
+
+class TestWebServerSeedGeneration(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = Path(__file__).resolve().parent.parent
+        sys.path.insert(0, str(self.repo_root / "src"))
+
+    def test_web_server_seed_generation_logic(self):
+        """Test that the web server generates seeds correctly when seed is None."""
+        # Import the actual web server module
+        try:
+            from zimage.server import app
+            from fastapi.testclient import TestClient
+        except ImportError:
+            self.skipTest("FastAPI not available")
+            return
+        
+        # Create a test client
+        client = TestClient(app)
+        
+        # Mock the heavy dependencies with proper async mocks
+        # Create a callable async mock that tracks invocations
+        run_worker_calls = []
+        
+        async def mock_run_worker(func, **kwargs):
+            run_worker_calls.append((func, kwargs))
+            return func(**kwargs)
+        
+        with patch('zimage.server.generate_image') as mock_generate_image, \
+             patch('zimage.server.save_image') as mock_save_image, \
+             patch('zimage.server.record_generation') as mock_record_generation, \
+             patch('zimage.server.run_in_worker', side_effect=mock_run_worker), \
+             patch('zimage.server.cleanup_memory'):
+            
+            # Setup mocks
+            mock_image = MagicMock()
+            mock_image.width = 256
+            mock_image.height = 256
+            mock_generate_image.return_value = mock_image
+            
+            mock_path = MagicMock()
+            mock_path.name = "test_image.png"
+            mock_path.stat.return_value.st_size = 1024
+            mock_save_image.return_value = mock_path
+            
+            mock_record_generation.return_value = 1
+            
+            # Make the request with seed=None (omit seed field to test default None behavior)
+            response = client.post("/generate", json={
+                "prompt": "test prompt",
+                "steps": 2,
+                "width": 256,
+                "height": 256,
+                # Omit seed field to test the default None behavior
+                "precision": "q8"
+            })
+            
+            # Verify the response
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            
+            # The key assertion: seed should NOT be null, it should be a generated integer
+            self.assertIn("seed", data, "Seed not found in response")
+            self.assertIsNotNone(data["seed"], "Seed should not be null")
+            self.assertIsInstance(data["seed"], int, f"Seed should be an integer, got {type(data['seed'])}")
+            self.assertGreaterEqual(data["seed"], 0, "Seed should be non-negative")
+            self.assertLessEqual(data["seed"], 2**31 - 1, f"Seed {data['seed']} should be within valid range")
+            
+            # Verify that run_in_worker was actually called (to ensure endpoint uses it)
+            self.assertGreater(len(run_worker_calls), 0, "run_in_worker should have been called")
+            
+            # Verify that generate_image was called through run_in_worker
+            self.assertEqual(len(run_worker_calls), 1, "run_in_worker should be called exactly once")
+            called_func, called_kwargs = run_worker_calls[0]
+            self.assertIs(called_func, mock_generate_image, "run_in_worker should call the mocked generate_image function")
+            
+            # Verify that generate_image was called with the generated seed (not None)
+            mock_generate_image.assert_called_once()
+            call_kwargs = mock_generate_image.call_args[1]
+            self.assertIn("seed", call_kwargs)
+            self.assertIsNotNone(call_kwargs["seed"], "generate_image should be called with non-None seed")
+            self.assertIsInstance(call_kwargs["seed"], int, "generate_image seed should be an integer")
+            
+            # Verify that record_generation was called with the generated seed
+            mock_record_generation.assert_called_once()
+            call_kwargs = mock_record_generation.call_args[1]
+            self.assertIn("seed", call_kwargs)
+            self.assertIsNotNone(call_kwargs["seed"], "record_generation should be called with non-None seed")
+            self.assertIsInstance(call_kwargs["seed"], int, "record_generation seed should be an integer")
+
+    def test_web_server_seed_preservation(self):
+        """Test that the web server preserves provided seeds."""
+        try:
+            from zimage.server import app
+            from fastapi.testclient import TestClient
+        except ImportError:
+            self.skipTest("FastAPI not available")
+            return
+        
+        client = TestClient(app)
+        
+        # Create a callable async mock that tracks invocations
+        run_worker_calls = []
+        
+        async def mock_run_worker(func, **kwargs):
+            run_worker_calls.append((func, kwargs))
+            return func(**kwargs)
+        
+        with patch('zimage.server.generate_image') as mock_generate_image, \
+             patch('zimage.server.save_image') as mock_save_image, \
+             patch('zimage.server.record_generation') as mock_record_generation, \
+             patch('zimage.server.run_in_worker', side_effect=mock_run_worker):
+            
+            # Setup mocks
+            mock_image = MagicMock()
+            mock_image.width = 256
+            mock_image.height = 256
+            mock_generate_image.return_value = mock_image
+            
+            mock_path = MagicMock()
+            mock_path.name = "test_image.png"
+            mock_path.stat.return_value.st_size = 1024
+            mock_save_image.return_value = mock_path
+            
+            mock_record_generation.return_value = 1
+            
+            # Test with a specific seed
+            test_seed = 12345
+            response = client.post("/generate", json={
+                "prompt": "test prompt",
+                "steps": 2,
+                "width": 256,
+                "height": 256,
+                "seed": test_seed,  # Provide a specific seed
+                "precision": "q8"
+            })
+            
+            # Verify the response
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            
+            # Should preserve the provided seed
+            self.assertEqual(data["seed"], test_seed, "Should preserve provided seed")
+            
+            # Verify that run_in_worker was actually called
+            self.assertGreater(len(run_worker_calls), 0, "run_in_worker should have been called")
+            self.assertEqual(len(run_worker_calls), 1, "run_in_worker should be called exactly once")
+            
+            # Verify that generate_image was called with the provided seed through run_in_worker
+            called_func, called_kwargs = run_worker_calls[0]
+            self.assertIs(called_func, mock_generate_image, "run_in_worker should call the mocked generate_image function")
+            self.assertEqual(called_kwargs["seed"], test_seed, "generate_image should be called with provided seed")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When be called via mcp server, the empty seed parameter can produce history record with null value of the seed.

This PR is to fix it by guard with a default random seed generation.