### PR TITLE
feat: encode the returned url in server

### DIFF
--- a/src/zimage/mcp_server.py
+++ b/src/zimage/mcp_server.py
@@ -8,6 +8,7 @@ import os
 import json
 import base64
 import random
+from urllib.parse import quote
 
 # Lazy import for yarl to avoid dependency issues
 try:
@@ -204,7 +205,9 @@ async def _generate_impl(
         raise
 
     base_url = os.getenv("ZIMAGE_BASE_URL")
-    relative_url = f"/outputs/{filename}"
+    # UTF-8 percent-encode the filename for URL safety and compatibility
+    encoded_filename = quote(filename, safe='')
+    relative_url = f"/outputs/{encoded_filename}"
 
     # Build appropriate URI based on transport context
     if transport in ("sse", "streamable_http"):
@@ -355,7 +358,8 @@ async def _generate_impl(
             )
     else:
         # For stdio transport, use file:// URI for local access
-        resource_uri = f"file://{output_path.resolve()}"
+        # URL-encode the path to handle spaces and special characters
+        resource_uri = f"file://{quote(str(output_path.resolve()), safe='/')}"
 
     # Create text content with generation info and file metadata
     # Note: For SSE (remote), we include the URL instead of local file path

--- a/src/zimage/server.py
+++ b/src/zimage/server.py
@@ -4,6 +4,7 @@ from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 from pathlib import Path
 from typing import Optional, List, Dict, Any, AsyncGenerator
+from urllib.parse import quote
 import asyncio
 import time
 import sqlite3
@@ -461,7 +462,7 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
         
         return {
             "id": new_id,
-            "image_url": f"/outputs/{filename}",
+            "image_url": f"/outputs/{quote(filename, safe='')}",
             "generation_time": round(duration, 2),
             "width": image.width,
             "height": image.height,


### PR DESCRIPTION
## Summary

- URL-encode returned image filenames in both server and MCP server
- Fixes potential issues with filenames containing spaces, special characters, or non-ASCII characters
- Applies encoding to both HTTP URLs (`/outputs/{filename}`) and file URIs