### PR TITLE
docs: add AgentSeal badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ![Intel XPU](https://img.shields.io/badge/Intel-XPU-gray?logo=intel)
 ![Docker](https://img.shields.io/badge/Docker-blue?logo=docker)
 [![Docs](https://img.shields.io/badge/docs-deepwiki.com-blue)](https://deepwiki.com/iconben/z-image-studio)
+[![AgentSeal MCP](https://agentseal.org/api/v1/mcp/https-githubcom-iconben-z-image-studio/badge)](https://agentseal.org/mcp/https-githubcom-iconben-z-image-studio)
 
 A Cli, a webUI, and a MCP server for the **Z-Image-Turbo** text-to-image generation model (`Tongyi-MAI/Z-Image-Turbo` and its variants).
 


### PR DESCRIPTION
Adds the AgentSeal MCP badge to the README.md file as requested in issue #85.

---
*PR created automatically by Jules for task [18065860486977651291](https://jules.google.com/task/18065860486977651291) started by @iconben*